### PR TITLE
add delete functionality w/ tests

### DIFF
--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -14,10 +14,12 @@ exports.helloWorld = functions.https.onRequest((request, response) => {
 const {
   addFlashcardSet,
   updateFlashcardSet,
+  deleteFlashcardSet,
 } = require("./src/controllers/flashcard");
 
 exports.addFlashcardSet = addFlashcardSet;
 exports.updateFlashcardSet = updateFlashcardSet;
+exports.deleteFlashcardSet = deleteFlashcardSet;
 
 
 const {newUserSignup} = require("./src/controllers/user");

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -15,11 +15,13 @@ const {
   addFlashcardSet,
   updateFlashcardSet,
   deleteFlashcardSet,
+  recoverFlashcardSet,
 } = require("./src/controllers/flashcard");
 
 exports.addFlashcardSet = addFlashcardSet;
 exports.updateFlashcardSet = updateFlashcardSet;
 exports.deleteFlashcardSet = deleteFlashcardSet;
+exports.recoverFlashcardSet = recoverFlashcardSet;
 
 
 const {newUserSignup} = require("./src/controllers/user");

--- a/backend/functions/src/controllers/flashcard.js
+++ b/backend/functions/src/controllers/flashcard.js
@@ -186,7 +186,13 @@ exports.deleteFlashcardSet = functions.https.onCall(async (data, context) => {
     // Delete the flashcard set in the "flashcards" database
     const docRef = admin.firestore().collection("flashcards").doc(flashcardId);
     await docRef.get().then((doc) => {
-      if (doc.data().creatorId === context.auth.uid) return docRef.delete();
+      if (doc.data().creatorId !== context.auth.uid) {
+        const errMsg =
+          "You do not have permission to delete this flashcard set.";
+        throw new functions.https.HttpsError("permission-denied", errMsg);
+      }
+      // We know the person who called this function is the owner
+      return docRef.delete();
     });
 
     // Remove the reference to the flashcard set in the "users" database

--- a/backend/functions/tests/flashcard.test.js
+++ b/backend/functions/tests/flashcard.test.js
@@ -298,7 +298,7 @@ describe("Testing Flashcard Set Functions", () => {
     );
   });
 
-  test("silently handles case of deleting unowned flashcard set", async () => {
+  test("throws error deleting flashcard set we don't own", async () => {
     // Create a test flashcard set for error cases
     const data = {
       creatorId: "fake-uuid",
@@ -311,15 +311,14 @@ describe("Testing Flashcard Set Functions", () => {
     docsToDelete.push(docRef.id); // For cleanup
 
     const context = {auth: {uid: user.uid}};
-    // Attempt to delete flashcard set [will not be deleted]
+    // Attempt to delete flashcard set
     const deleteFlashcardSet = fft.wrap(myFunctions.deleteFlashcardSet);
-    await deleteFlashcardSet({flashcardId: docRef.id}, context);
+    await expect(deleteFlashcardSet({flashcardId: docRef.id}, context)).rejects.toEqual(
+        new Error("You do not have permission to delete this flashcard set."),
+    );
 
     // Validate flashcard set still exists
     const doc = await admin.firestore().collection("flashcards").doc(docRef.id).get();
     expect(doc.exists).toBeTruthy();
-    for (const [key, value] of Object.entries(data)) {
-      expect(data[key]).toBe(value);
-    }
   });
 });

--- a/backend/functions/tests/flashcard.test.js
+++ b/backend/functions/tests/flashcard.test.js
@@ -317,7 +317,6 @@ describe("Testing Flashcard Set Functions", () => {
 
       // Valdiate flashcard set has been deleted
       const doc = await admin.firestore().collection("flashcards").doc(fcId).get();
-      console.log(doc.data());
       expect(doc.exists).not.toBeTruthy();
 
       // Validate reference to flashcard set ISN'T on "user" document

--- a/backend/functions/tests/flashcard.test.js
+++ b/backend/functions/tests/flashcard.test.js
@@ -329,10 +329,11 @@ describe("Testing Flashcard Set Functions", () => {
     test(`recover doc in /flashcards`, async () => {
       const data = {
         creatorId: user.uid,
-        title: "Doc to delete",
+        title: "Doc to recover",
         category: "Test",
         timestamp: Date.now(),
         cards: [{question: "Q", answer: "A"}],
+        toBeDeleted: true,
       };
       const docRef = await admin.firestore().collection("flashcards").add(data);
       const fcId = docRef.id;


### PR DESCRIPTION
Code for the delete functionality - deleting flashcard sets we own.
- If we don't own the flashcard set and we try to delete it, it'll be silently handled (ie: flashcard set won't be deleted and if the reference somehow exists on the user even if they don't own it, it'll be removed).
- Written tests for:
  - Deleting a flashcard set we own
  - Make sure we get an error if we try to delete a flashcard set while unauthenticated
  - Deleting a flashcard set we don't own and validating it wasn't deleted

**NOTE:** Should be merged into the "backend" branch once the PR for the update functionality is pushed.