### PR TITLE
Backend Testing Updates

### DIFF
--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -8,7 +8,7 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "engines": {
     "node": "16"

--- a/backend/functions/tests/flashcard.test.js
+++ b/backend/functions/tests/flashcard.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 const path = require("path");
+const crypto = require("crypto");
 
 const admin = require("firebase-admin");
 const fft = require("firebase-functions-test")(
@@ -12,7 +13,7 @@ describe("Testing Flashcard Set Functions", () => {
   let myFunctions;
   let user;
   const unownedFCSetData = {
-    creatorId: "fake-uuid",
+    creatorId: crypto.randomUUID(),
     title: "Unowned",
     category: "Test",
     timestamp: Date.now(),
@@ -32,10 +33,11 @@ describe("Testing Flashcard Set Functions", () => {
   beforeAll(async () => {
     myFunctions = require("../index");
 
+    const randUUID = crypto.randomUUID();
     // Create a test user
     user = fft.auth.exampleUserRecord();
-    user.uid = "test-id-2";
-    user.email = "testuser2@gmail.com";
+    user.uid = randUUID;
+    user.email = `testuser-${randUUID}@gmail.com`;
     const newUserSignup = fft.wrap(myFunctions.newUserSignup);
     await newUserSignup(user);
 

--- a/backend/functions/tests/user.test.js
+++ b/backend/functions/tests/user.test.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const crypto = require("crypto");
 
 const admin = require("firebase-admin");
 const fft = require("firebase-functions-test")(
@@ -13,10 +14,12 @@ describe("newUserSignup", () => {
 
   beforeAll(() => {
     myFunctions = require("../index");
+
+    const randUUID = crypto.randomUUID();
     // Create a test user
     user = fft.auth.exampleUserRecord();
-    user.uid = "test-id-1";
-    user.email = "testuser1@gmail.com";
+    user.uid = randUUID;
+    user.email = `testuser-${randUUID}@gmail.com`;
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Test Coverage Chart
Replaced what `npm test` does from just `jest` to `jest --coverage`.
- This now displays a chart detailing test coverage in our backend code.

**Example result:**
![image](https://user-images.githubusercontent.com/83375816/235242501-13f129e0-b371-44ec-928f-c3ccc85e08c6.png)

This generates an `index.html` file which shows the results as an `html` page:
![image](https://user-images.githubusercontent.com/83375816/235242783-739fb566-b995-4158-be05-8fd2335afd40.png)
**`html` page generated:**
![image](https://user-images.githubusercontent.com/83375816/235242878-cea06545-d1d3-46b5-84a2-8d34ca6e9a6a.png)

## Fixing Concurrent Tests Issue w/ GitHub Actions
Fixed issue when the tests were run with GitHub Actions and some tests were failing due to be running concurrently.
- I narrowed down the issue to the fact that we utilized the same user ids for each tests, so when cleanup occurred, it'll delete the contents used by the other tests running concurrently.
- I fixed it by now using node's `crypto` library to generate unique uuid values so we don't have this issue.
