### PR TITLE
Updated Firebase Rules

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -4,5 +4,14 @@ service cloud.firestore {
     match /{document=**} {
       allow read, write: if false;
     }
+    // Allow auth user to view their own user document
+    match /users/{userId} {
+    	allow read: if request.auth.uid != null && request.auth.uid == userId;
+    }
+    // Flashcards can only be accessed by user who created it
+    //  - Ref: https://firebase.google.com/docs/firestore/security/rules-conditions#data_validation
+    match /flashcards/{flashcardId} {
+    	allow read: if request.auth.uid != null && resource.data.creatorId == request.auth.uid;
+    }
   }
 }


### PR DESCRIPTION
Essentially restrict database access of documents (this is to reflect the live changes):
- We give access to the `/users/{userId}` document if the current user is authenticated and their `uid` value equals `userId`.
- We give access to the `/flashcards/{flashcardId}` document if the current user is authenticated an their `uid` equals to the `creatorId` value in the specific flashcard document.